### PR TITLE
Handle alternate spelling for docker user-agent

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -95,7 +95,7 @@ func (ds *dockerServer) ModifyResponse(resp *http.Response) error {
 func (ds *dockerServer) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc(ds.host+"/", func(rw http.ResponseWriter, r *http.Request) {
 		ua := r.UserAgent()
-		ua1 := strings.HasPrefix(ua, "docker/")
+		ua1 := strings.HasPrefix(ua, "docker/") || strings.HasPrefix(ua, "Docker/")
 		ua2 := strings.HasPrefix(ua, "Go-")
 		if !ua1 && !ua2 {
 			handler(rw, r)


### PR DESCRIPTION
Some docker instances are unable to login through Beyond. That's because the user-agent is spelled with a D instead of a d.
Examples of these user-agents include:
- Docker-Client/20.10.7 (darwin)
- Docker-Client/nerdctl-v0.12.1 (linux)

